### PR TITLE
Changes to shape objects to explicitly set opaque property when changing colors

### DIFF
--- a/adafruit_display_shapes/rect.py
+++ b/adafruit_display_shapes/rect.py
@@ -76,7 +76,9 @@ class Rect(displayio.TileGrid):
 
         if fill is not None:
             self._palette[0] = fill
+            self._palette.make_opaque(0)
         else:
+            self._palette[0] = 0
             self._palette.make_transparent(0)
         super().__init__(self._bitmap, pixel_shader=self._palette, x=x, y=y)
 
@@ -89,9 +91,11 @@ class Rect(displayio.TileGrid):
     @fill.setter
     def fill(self, color):
         if color is None:
+            self._palette[0] = 0
             self._palette.make_transparent(0)
         else:
             self._palette[0] = color
+            self._palette.make_opaque(0)
 
     @property
     def outline(self):
@@ -102,6 +106,8 @@ class Rect(displayio.TileGrid):
     @outline.setter
     def outline(self, color):
         if color is None:
+            self._palette[1] = 0
             self._palette.make_transparent(1)
         else:
             self._palette[1] = color
+            self._palette.make_opaque(1)

--- a/adafruit_display_shapes/roundrect.py
+++ b/adafruit_display_shapes/roundrect.py
@@ -20,21 +20,11 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 """
-`roundrect`
+`my_roundrect`
 ================================================================================
 
-Various common shapes for use with displayio - Rounded Rectangle shape!
-
-
-* Author(s): Limor Fried
-
-Implementation Notes
---------------------
-
-**Software and Dependencies:**
-
-* Adafruit CircuitPython firmware for the supported boards:
-  https://github.com/adafruit/circuitpython/releases
+A slightly modified version of Adafruit_CircuitPython_Display_Shapes that includes
+an explicit call to palette.make_opaque() in the fill color setter function.
 
 """
 
@@ -65,16 +55,18 @@ class RoundRect(displayio.TileGrid):
         self._palette = displayio.Palette(3)
         self._palette.make_transparent(0)
         self._bitmap = displayio.Bitmap(width, height, 3)
+        for i in range(0, width):   # draw the center chunk
+            for j in range(r, height - r):   # draw the center chunk
+                self._bitmap[i, j] = 2
+        self._helper(r, r, r, color=2, fill=True,
+                    x_offset=width-2*r-1, y_offset=height-2*r-1)
 
         if fill is not None:
-            for i in range(0, width):   # draw the center chunk
-                for j in range(r, height - r):   # draw the center chunk
-                    self._bitmap[i, j] = 2
-            self._helper(r, r, r, color=2, fill=True,
-                         x_offset=width-2*r-1, y_offset=height-2*r-1)
             self._palette[2] = fill
+            self._palette.make_opaque(2)
         else:
             self._palette.make_transparent(2)
+            self._palette[2] = 0
 
         if outline is not None:
             self._palette[1] = outline
@@ -148,9 +140,11 @@ class RoundRect(displayio.TileGrid):
     @fill.setter
     def fill(self, color):
         if color is None:
+            self._palette[2] = 0
             self._palette.make_transparent(2)
         else:
             self._palette[2] = color
+            self._palette.make_opaque(2)
 
     @property
     def outline(self):
@@ -161,6 +155,8 @@ class RoundRect(displayio.TileGrid):
     @outline.setter
     def outline(self, color):
         if color is None:
+            self._palette[1] = 0
             self._palette.make_transparent(1)
         else:
             self._palette[1] = color
+            self._palette.make_opaque(2)

--- a/adafruit_display_shapes/roundrect.py
+++ b/adafruit_display_shapes/roundrect.py
@@ -20,7 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 """
-`my_roundrect`
+`roundrect`
 ================================================================================
 
 A slightly modified version of Adafruit_CircuitPython_Display_Shapes that includes

--- a/adafruit_display_shapes/roundrect.py
+++ b/adafruit_display_shapes/roundrect.py
@@ -59,7 +59,7 @@ class RoundRect(displayio.TileGrid):
             for j in range(r, height - r):   # draw the center chunk
                 self._bitmap[i, j] = 2
         self._helper(r, r, r, color=2, fill=True,
-                    x_offset=width-2*r-1, y_offset=height-2*r-1)
+                     x_offset=width-2*r-1, y_offset=height-2*r-1)
 
         if fill is not None:
             self._palette[2] = fill

--- a/adafruit_display_shapes/triangle.py
+++ b/adafruit_display_shapes/triangle.py
@@ -89,7 +89,7 @@ class Triangle(displayio.TileGrid):
             self._palette.make_transparent(2)
 
         if outline is not None:
-            print("outline")
+            # print("outline")
             self._palette[1] = outline
             self._line(x0 - min(xs), 0, x1 - min(xs), y1 - y0, 1)
             self._line(x1 - min(xs), y1 - y0, x2 - min(xs), y2 - y0, 1)
@@ -186,9 +186,11 @@ class Triangle(displayio.TileGrid):
     @fill.setter
     def fill(self, color):
         if color is None:
+            self._palette[2] = 0
             self._palette.make_transparent(2)
         else:
             self._palette[2] = color
+            self._palette.make_opaque(2)
 
     @property
     def outline(self):
@@ -199,6 +201,8 @@ class Triangle(displayio.TileGrid):
     @outline.setter
     def outline(self, color):
         if color is None:
+            self._palette[1] = 0
             self._palette.make_transparent(1)
         else:
             self._palette[1] = color
+            self._palette.make_opaque(1)


### PR DESCRIPTION
When a shapes color or transparency is being changed the proper transparent or opaque properties need to be changed in case it is going from a transparent to opaque state (or vice-versa). Also, in the roundrect __init__ the chunk needs to be drawn even if the initial fill is None; otherwise there seems to be nothing to change the color of later on.