### PR TITLE
allow stroke parameter for Circle()

### DIFF
--- a/adafruit_display_shapes/circle.py
+++ b/adafruit_display_shapes/circle.py
@@ -45,6 +45,7 @@ __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_Display_Shapes.gi
 
 
 class Circle(RoundRect):
+    # pylint: disable=too-few-public-methods, invalid-name
     """A circle.
 
     :param x0: The x-position of the center.

--- a/adafruit_display_shapes/circle.py
+++ b/adafruit_display_shapes/circle.py
@@ -54,10 +54,18 @@ class Circle(RoundRect):
                  ``None`` for transparent.
     :param outline: The outline of the rounded-corner rectangle. Can be a hex value for a color or
                     ``None`` for no outline.
+    :param stroke: Used for the outline. Will not change the radius.
 
     """
 
-    def __init__(self, x0, y0, r, *, fill=None, outline=None):
+    def __init__(self, x0, y0, r, *, fill=None, outline=None, stroke=1):
         super().__init__(
-            x0 - r, y0 - r, 2 * r + 1, 2 * r + 1, r, fill=fill, outline=outline
+            x0 - r,
+            y0 - r,
+            2 * r + 1,
+            2 * r + 1,
+            r,
+            fill=fill,
+            outline=outline,
+            stroke=stroke,
         )

--- a/adafruit_display_shapes/line.py
+++ b/adafruit_display_shapes/line.py
@@ -45,7 +45,7 @@ __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_Display_Shapes.gi
 
 
 class Line(Polygon):
-    # pylint: disable=too-many-arguments,invalid-name
+    # pylint: disable=too-many-arguments,invalid-name, too-few-public-methods
     """A line.
 
     :param x0: The x-position of the first vertex.


### PR DESCRIPTION
Circle is extending RoundRect which already has support for `stroke`. It wasn't being accepted as a parameter on Circle `__init__()` however so it was not working with Circle. 

This change accepts `stroke` with a default of `1` and passes it through to the super class RoundRect constructor.

```python
circle = Circle(100, 100, 20, fill=0x00FF00, outline=0xFF00FF, stroke=5)
```