### PR TITLE
Corrected off-by-one error in __init__

### DIFF
--- a/adafruit_display_shapes/rect.py
+++ b/adafruit_display_shapes/rect.py
@@ -69,11 +69,11 @@ class Rect(displayio.TileGrid):
             for w in range(width):
                 for line in range(stroke):
                     self._bitmap[w, line] = 1
-                    self._bitmap[w, height - 1 - line] = 1
+                    self._bitmap[w, height - line] = 1
             for _h in range(height):
                 for line in range(stroke):
                     self._bitmap[line, _h] = 1
-                    self._bitmap[width - 1 - line, _h] = 1
+                    self._bitmap[width - line, _h] = 1
 
         if fill is not None:
             self._palette[0] = fill


### PR DESCRIPTION
Correcting an off-by-one error in `__init__` for rect.py for `Rectangle`.

This is described in https://github.com/adafruit/Adafruit_CircuitPython_Display_Shapes/issues/18.

#### Potential negative impact
If this is updated, any existing working code will be off-by-one in the other direction.