### PR TITLE
Corrects off-by-one error in due to rounding errors

### DIFF
--- a/adafruit_display_shapes/rect.py
+++ b/adafruit_display_shapes/rect.py
@@ -69,11 +69,11 @@ class Rect(displayio.TileGrid):
             for w in range(width):
                 for line in range(stroke):
                     self._bitmap[w, line] = 1
-                    self._bitmap[w, height - 1 - line] = 1
+                    self._bitmap[w, height - line] = 1
             for _h in range(height):
                 for line in range(stroke):
                     self._bitmap[line, _h] = 1
-                    self._bitmap[width -1 - line, _h] = 1
+                    self._bitmap[width - line, _h] = 1
 
         if fill is not None:
             self._palette[0] = fill

--- a/adafruit_display_shapes/rect.py
+++ b/adafruit_display_shapes/rect.py
@@ -69,11 +69,11 @@ class Rect(displayio.TileGrid):
             for w in range(width):
                 for line in range(stroke):
                     self._bitmap[w, line] = 1
-                    self._bitmap[w, height - line] = 1
+                    self._bitmap[w, height - 1 - line] = 1
             for _h in range(height):
                 for line in range(stroke):
                     self._bitmap[line, _h] = 1
-                    self._bitmap[width - line, _h] = 1
+                    self._bitmap[width -1 - line, _h] = 1
 
         if fill is not None:
             self._palette[0] = fill

--- a/adafruit_display_shapes/rect.py
+++ b/adafruit_display_shapes/rect.py
@@ -69,11 +69,11 @@ class Rect(displayio.TileGrid):
             for w in range(width):
                 for line in range(stroke):
                     self._bitmap[w, line] = 1
-                    self._bitmap[w, height - 1 - line] = 1
+                    self._bitmap[w, height - line] = 1
             for _h in range(height):
                 for line in range(stroke):
                     self._bitmap[line, _h] = 1
-                    self._bitmap[width - 1 - line, _h] = 1
+                    self._bitmap[width - line, _h] = 1
 
         if fill is not None:
             self._palette[0] = fill

--- a/adafruit_display_shapes/rect.py
+++ b/adafruit_display_shapes/rect.py
@@ -69,11 +69,11 @@ class Rect(displayio.TileGrid):
             for w in range(width):
                 for line in range(stroke):
                     self._bitmap[w, line] = 1
-                    self._bitmap[w, height - line] = 1
+                    self._bitmap[w, height - 1 - line] = 1
             for _h in range(height):
                 for line in range(stroke):
                     self._bitmap[line, _h] = 1
-                    self._bitmap[width - line, _h] = 1
+                    self._bitmap[width - 1 - line, _h] = 1
 
         if fill is not None:
             self._palette[0] = fill

--- a/adafruit_display_shapes/sparkline.py
+++ b/adafruit_display_shapes/sparkline.py
@@ -139,7 +139,7 @@ class Sparkline(displayio.Group):
             self.y_top = self.y_max
 
         if len(self._spark_list) > 2:
-            xpitch = self.width / (
+            xpitch = (self.width-1) / (
                 len(self._spark_list) - 1
             )  # this is a float, only make int when plotting the line
 

--- a/adafruit_display_shapes/sparkline.py
+++ b/adafruit_display_shapes/sparkline.py
@@ -139,7 +139,7 @@ class Sparkline(displayio.Group):
             self.y_top = self.y_max
 
         if len(self._spark_list) > 2:
-            xpitch = (self.width-1) / (
+            xpitch = (self.width - 1) / (
                 len(self._spark_list) - 1
             )  # this is a float, only make int when plotting the line
 

--- a/adafruit_display_shapes/sparkline.py
+++ b/adafruit_display_shapes/sparkline.py
@@ -139,7 +139,7 @@ class Sparkline(displayio.Group):
             self.y_top = self.y_max
 
         if len(self._spark_list) > 2:
-            xpitch = (self.width-1) / (
+            xpitch = self.width / (
                 len(self._spark_list) - 1
             )  # this is a float, only make int when plotting the line
 

--- a/examples/display_shapes_sparkline_ticks.py
+++ b/examples/display_shapes_sparkline_ticks.py
@@ -109,8 +109,8 @@ sparkline1 = Sparkline(
     max_items=40,
     y_min=0,
     y_max=10,
-    x=20,
-    y=20,
+    x=40,
+    y=30,
     color=line_color,
 )
 
@@ -137,7 +137,7 @@ text_label1b.anchored_position = (
 
 
 bounding_rectangle = Rect(
-    sparkline1.x, sparkline1.y, chart_width, chart_height, outline=line_color
+    sparkline1.x, sparkline1.y, chart_width + 1, chart_height + 1, outline=line_color
 )
 
 
@@ -157,15 +157,20 @@ my_group.append(bounding_rectangle)
 
 total_ticks = 10
 
-for i in range(total_ticks+1):
+for i in range(total_ticks + 1):
     x_start = sparkline1.x - 5
     x_end = sparkline1.x
-    y_both = int(round(sparkline1.y + (i * (chart_height) / (total_ticks))))
-    if y_both > sparkline1.y+chart_height-1:
-        y_both = sparkline1.y+chart_height-1
-    print('y_both: {}, i: {}'.format(y_both, i))
+    y_both = sparkline1.y + i * int(round(chart_height / (total_ticks)))
     my_group.append(Line(x_start, y_both, x_end, y_both, color=line_color))
-
+my_group.append(
+    Line(
+        x_start,
+        sparkline1.y + chart_height,
+        x_end,
+        sparkline1.y + chart_height,
+        color=line_color,
+    )
+)
 
 # Set the display to show my_group that contains the sparkline and other graphics
 display.show(my_group)

--- a/examples/display_shapes_sparkline_ticks.py
+++ b/examples/display_shapes_sparkline_ticks.py
@@ -109,8 +109,8 @@ sparkline1 = Sparkline(
     max_items=40,
     y_min=0,
     y_max=10,
-    x=20,
-    y=20,
+    x=40,
+    y=30,
     color=line_color,
 )
 

--- a/examples/display_shapes_sparkline_ticks.py
+++ b/examples/display_shapes_sparkline_ticks.py
@@ -157,13 +157,12 @@ my_group.append(bounding_rectangle)
 
 total_ticks = 10
 
-for i in range(total_ticks+1):
+for i in range(total_ticks + 1):
     x_start = sparkline1.x - 5
     x_end = sparkline1.x
     y_both = int(round(sparkline1.y + (i * (chart_height) / (total_ticks))))
-    if y_both > sparkline1.y+chart_height-1:
-        y_both = sparkline1.y+chart_height-1
-    print('y_both: {}, i: {}'.format(y_both, i))
+    if y_both > sparkline1.y + chart_height - 1:
+        y_both = sparkline1.y + chart_height - 1
     my_group.append(Line(x_start, y_both, x_end, y_both, color=line_color))
 
 

--- a/examples/display_shapes_sparkline_ticks.py
+++ b/examples/display_shapes_sparkline_ticks.py
@@ -109,8 +109,8 @@ sparkline1 = Sparkline(
     max_items=40,
     y_min=0,
     y_max=10,
-    x=40,
-    y=30,
+    x=20,
+    y=20,
     color=line_color,
 )
 
@@ -137,7 +137,7 @@ text_label1b.anchored_position = (
 
 
 bounding_rectangle = Rect(
-    sparkline1.x, sparkline1.y, chart_width + 1, chart_height + 1, outline=line_color
+    sparkline1.x, sparkline1.y, chart_width, chart_height, outline=line_color
 )
 
 
@@ -157,20 +157,15 @@ my_group.append(bounding_rectangle)
 
 total_ticks = 10
 
-for i in range(total_ticks + 1):
+for i in range(total_ticks+1):
     x_start = sparkline1.x - 5
     x_end = sparkline1.x
-    y_both = sparkline1.y + i * int(round(chart_height / (total_ticks)))
+    y_both = int(round(sparkline1.y + (i * (chart_height) / (total_ticks))))
+    if y_both > sparkline1.y+chart_height-1:
+        y_both = sparkline1.y+chart_height-1
+    print('y_both: {}, i: {}'.format(y_both, i))
     my_group.append(Line(x_start, y_both, x_end, y_both, color=line_color))
-my_group.append(
-    Line(
-        x_start,
-        sparkline1.y + chart_height,
-        x_end,
-        sparkline1.y + chart_height,
-        color=line_color,
-    )
-)
+
 
 # Set the display to show my_group that contains the sparkline and other graphics
 display.show(my_group)


### PR DESCRIPTION
I updated how the rounding is performed to eliminate the x-axis from printing past the size of the box.

Also, I resolved a similar rounding issue in the tick-mark placement for the `_sparkline_ticks.py` example.