### PR TITLE
Fix documentation errors

### DIFF
--- a/adafruit_display_shapes/sparkline.py
+++ b/adafruit_display_shapes/sparkline.py
@@ -123,9 +123,7 @@ class Sparkline(displayio.Group):
     # pylint: disable= too-many-branches, too-many-nested-blocks
 
     def update(self):
-        """Update the drawing of the sparkline
-
-        """
+        """Update the drawing of the sparkline."""
 
         # get the y range
         if self.y_min is None:

--- a/adafruit_display_shapes/sparkline.py
+++ b/adafruit_display_shapes/sparkline.py
@@ -40,7 +40,7 @@ from adafruit_display_shapes.line import Line
 
 class Sparkline(displayio.Group):
     # pylint: disable=too-many-arguments
-    """ A sparkline graph.
+    """A sparkline graph.
 
     :param width: Width of the sparkline graph in pixels
     :param height: Height of the sparkline graph in pixels
@@ -86,7 +86,7 @@ class Sparkline(displayio.Group):
         )  # self is a group of lines
 
     def add_value(self, value):
-        """ Add a value to the sparkline.
+        """Add a value to the sparkline.
         :param value: The value to be added to the sparkline
         """
 

--- a/adafruit_display_shapes/sparkline.py
+++ b/adafruit_display_shapes/sparkline.py
@@ -212,6 +212,6 @@ class Sparkline(displayio.Group):
                 last_value = value  # store value for the next iteration
 
     def values(self):
-        """Returns the values displayed on the sparkline"""
+        """Returns the values displayed on the sparkline."""
 
         return self._spark_list

--- a/adafruit_display_shapes/sparkline.py
+++ b/adafruit_display_shapes/sparkline.py
@@ -42,14 +42,14 @@ class Sparkline(displayio.Group):
     # pylint: disable=too-many-arguments
     """ A sparkline graph.
 
-    : param width: Width of the sparkline graph in pixels
-    : param height: Height of the sparkline graph in pixels
-    : param max_items: Maximum number of values housed in the sparkline
-    : param y_min: Lower range for the y-axis.  Set to None for autorange.
-    : param y_max: Upper range for the y-axis.  Set to None for autorange.
-    : param x: X-position on the screen, in pixels
-    : param y: Y-position on the screen, in pixels
-    : param color: Line color, the default value is 0xFFFFFF (WHITE)
+    :param width: Width of the sparkline graph in pixels
+    :param height: Height of the sparkline graph in pixels
+    :param max_items: Maximum number of values housed in the sparkline
+    :param y_min: Lower range for the y-axis.  Set to None for autorange.
+    :param y_max: Upper range for the y-axis.  Set to None for autorange.
+    :param x: X-position on the screen, in pixels
+    :param y: Y-position on the screen, in pixels
+    :param color: Line color, the default value is 0xFFFFFF (WHITE)
     """
 
     def __init__(
@@ -87,7 +87,7 @@ class Sparkline(displayio.Group):
 
     def add_value(self, value):
         """ Add a value to the sparkline.
-        : param value: The value to be added to the sparkline
+        :param value: The value to be added to the sparkline
         """
 
         if value is not None:
@@ -212,7 +212,6 @@ class Sparkline(displayio.Group):
                 last_value = value  # store value for the next iteration
 
     def values(self):
-        """Returns the values displayed on the sparkline
-        """
+        """Returns the values displayed on the sparkline"""
 
         return self._spark_list

--- a/examples/display_shapes_sparkline_ticks.py
+++ b/examples/display_shapes_sparkline_ticks.py
@@ -31,10 +31,11 @@ import time
 import board
 import displayio
 import terminalio
+from adafruit_display_text import label
 from adafruit_display_shapes.sparkline import Sparkline
 from adafruit_display_shapes.line import Line
 from adafruit_display_shapes.rect import Rect
-from adafruit_display_text import label
+
 
 if "DISPLAY" not in dir(board):
     # Setup the LCD display with driver

--- a/examples/display_shapes_sparkline_triple.py
+++ b/examples/display_shapes_sparkline_triple.py
@@ -31,8 +31,9 @@ import time
 import board
 import displayio
 import terminalio
-from adafruit_display_shapes.sparkline import Sparkline
 from adafruit_display_text import label
+from adafruit_display_shapes.sparkline import Sparkline
+
 
 if "DISPLAY" not in dir(board):
     # Setup the LCD display with driver


### PR DESCRIPTION
This fixes some errors in the documentation formatting for `Sparkline`.

There were some excess spaces in the documentation that was causing errors in the parsing:

<img width="729" alt="image" src="https://user-images.githubusercontent.com/33587466/92611764-be41b600-f27e-11ea-90de-9bab512a391a.png">
