### PR TITLE
Remove fill argument definition from Sphinx docstring

### DIFF
--- a/adafruit_display_shapes/polygon.py
+++ b/adafruit_display_shapes/polygon.py
@@ -49,8 +49,6 @@ class Polygon(displayio.TileGrid):
     """A polygon.
 
     :param points: A list of (x, y) tuples of the points
-    :param fill: The color to fill the polygon. Can be a hex value for a color or
-                 ``None`` for transparent.
     :param outline: The outline of the polygon. Can be a hex value for a color or
                     ``None`` for no outline.
     """


### PR DESCRIPTION
This looks like a copy-paste error from one of the other shape types.