### PR TITLE
Fix typos in Sphinx class string

### DIFF
--- a/adafruit_display_shapes/circle.py
+++ b/adafruit_display_shapes/circle.py
@@ -32,12 +32,12 @@ class Circle(RoundRect):
     """A circle.
 
     :param x0: The x-position of the center.
-    :param y0: The y-position of the center..
+    :param y0: The y-position of the center.
     :param r: The radius of the circle.
-    :param fill: The color to fill the rounded-corner rectangle. Can be a hex value for a color or
+    :param fill: The color to fill the circle. Can be a hex value for a color or
                  ``None`` for transparent.
-    :param outline: The outline of the rounded-corner rectangle. Can be a hex value for a color or
-                    ``None`` for no outline.
+    :param outline: The outline of the circle. Can be a hex value for a color or
+                 ``None`` for no outline.
     :param stroke: Used for the outline. Will not change the radius.
 
     """


### PR DESCRIPTION
Fixed copy-paste error: "rounded rectangle" => "circle," which didn't even affect line wrapping!

Minor typos also fixed: unified indenting for wrapped line. Removed an extra period.