### PR TITLE
Function that clears the _spark_list list

### DIFF
--- a/adafruit_display_shapes/sparkline.py
+++ b/adafruit_display_shapes/sparkline.py
@@ -1,5 +1,8 @@
+# SPDX-FileCopyrightText: 2020 Kevin Matocha
+#
+# SPDX-License-Identifier: MIT
+
 # class of sparklines in CircuitPython
-# created by Kevin Matocha - Copyright 2020 (C)
 
 # See the bottom for a code example using the `sparkline` Class.
 
@@ -33,6 +36,8 @@ Implementation Notes
   https://github.com/adafruit/circuitpython/releases
 
 """
+
+#pylint: disable=too-many-instance-attributes
 
 import displayio
 from adafruit_display_shapes.line import Line
@@ -84,6 +89,13 @@ class Sparkline(displayio.Group):
         super().__init__(
             max_size=self._max_items - 1, x=x, y=y
         )  # self is a group of lines
+
+    def clear_values(self):
+        """Removes all values from the _spark_list list and removes all lines in the group"""
+
+        for _ in range(len(self)):  # remove all items from the current group
+            self.pop()
+        self._spark_list = []  # empty the list
 
     def add_value(self, value):
         """Add a value to the sparkline.

--- a/adafruit_display_shapes/sparkline.py
+++ b/adafruit_display_shapes/sparkline.py
@@ -37,7 +37,7 @@ Implementation Notes
 
 """
 
-#pylint: disable=too-many-instance-attributes
+# pylint: disable=too-many-instance-attributes
 
 import displayio
 from adafruit_display_shapes.line import Line

--- a/adafruit_display_shapes/sparkline.py
+++ b/adafruit_display_shapes/sparkline.py
@@ -88,6 +88,9 @@ class Sparkline(displayio.Group):
             max_size=self._max_items - 1, x=x, y=y
         )  # self is a group of lines
 
+    def clear_values(self):
+        self._spark_list = []
+
     def add_value(self, value):
         """Add a value to the sparkline.
         :param value: The value to be added to the sparkline
@@ -116,7 +119,7 @@ class Sparkline(displayio.Group):
                 horizontal_y - b
             ) / slope  # calculate the x-intercept at position y=horizontalY
             return int(xint)
-
+        
     def _plotline(self, x_1, last_value, x_2, value, y_bottom, y_top):
 
         y_2 = int(self.height * (y_top - value) / (y_top - y_bottom))

--- a/adafruit_display_shapes/sparkline.py
+++ b/adafruit_display_shapes/sparkline.py
@@ -89,7 +89,11 @@ class Sparkline(displayio.Group):
         )  # self is a group of lines
 
     def clear_values(self):
-        self._spark_list = []
+        """Removes all values from the _spark_list list and removes all lines in the group"""
+
+        for _ in range(len(self)):  # remove all items from the current group
+            self.pop()
+        self._spark_list = []  # empty the list
 
     def add_value(self, value):
         """Add a value to the sparkline.

--- a/adafruit_display_shapes/sparkline.py
+++ b/adafruit_display_shapes/sparkline.py
@@ -123,7 +123,7 @@ class Sparkline(displayio.Group):
                 horizontal_y - b
             ) / slope  # calculate the x-intercept at position y=horizontalY
             return int(xint)
-        
+
     def _plotline(self, x_1, last_value, x_2, value, y_bottom, y_top):
 
         y_2 = int(self.height * (y_top - value) / (y_top - y_bottom))


### PR DESCRIPTION
Tested on my pyportal using circuitpython 6.1.0, seems to work as expected. Fairly simple change but I find it quite useful being able to clear a sparkline without reinstating it.