### PR TITLE
Add simple round rect

### DIFF
--- a/adafruit_display_shapes/simpleroundrect.py
+++ b/adafruit_display_shapes/simpleroundrect.py
@@ -49,7 +49,7 @@ class SimpleRoundRect(displayio.TileGrid):
         palette.make_transparent(0)
         palette[1] = fill
 
-        # these them so fill can be adjusted later
+        # save these so fill can be adjusted later
         self._palette = palette
         self._shape = shape
 
@@ -75,6 +75,7 @@ class SimpleRoundRect(displayio.TileGrid):
 
     @property
     def fill(self):
+        """The infill color, this can be set with rgb hex or `None` for clear"""
         return self._palette[1]
 
     @fill.setter
@@ -87,12 +88,15 @@ class SimpleRoundRect(displayio.TileGrid):
 
     @property
     def width(self):
+        """The horizonal dimension of the rectangle in pixels"""
         return self._width
 
     @property
     def height(self):
+        """The vertical dimension of the rectangle in pixels"""
         return self._height
 
     @property
     def radius(self):
+        """The radius for the corners in pixels"""
         return self._radius

--- a/adafruit_display_shapes/simpleroundrect.py
+++ b/adafruit_display_shapes/simpleroundrect.py
@@ -54,7 +54,7 @@ class SimpleRoundRect(displayio.TileGrid):
         self._shape = shape
 
         # clip a too large radius to the max allowed
-        radius = min(radius, round(width / 2), round(height / 2))
+        radius = min(radius, width // 2, height // 2)
 
         # calculate and apply the radius row by row
         rsqrd = radius ** 2

--- a/adafruit_display_shapes/simpleroundrect.py
+++ b/adafruit_display_shapes/simpleroundrect.py
@@ -19,6 +19,19 @@ __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_Display_Shapes.gi
 
 
 class SimpleRoundRect(displayio.TileGrid):
+    # pylint: disable=too-many-arguments
+    """A round-corner rectangle with a smaller memory foorprint. All the corners
+        have the same same radius.
+
+    :param x: The x-position of the top left corner.
+    :param y: The y-position of the top left corner.
+    :param width: The width of the rounded-corner rectangle.
+    :param height: The height of the rounded-corner rectangle.
+    :param radius: The radius of the rounded corner.
+    :param fill: The color to fill the rounded-corner rectangle. Can be a hex value for a color or
+                 ``None`` for transparent.
+    """
+
     def __init__(self, x, y, width, height, radius=0, fill=0xFF0000):
 
         # the palette and shpae can only be stored after __init__
@@ -26,9 +39,9 @@ class SimpleRoundRect(displayio.TileGrid):
         shape = displayio.Shape(
             width,
             height,
-            # mirror_x and mirror_y are False until a core displayio bug is fixed
+            # mirror_x is False due to a core displayio bug
             mirror_x=False,
-            mirror_y=False,
+            mirror_y=True,
         )
         super().__init__(shape, pixel_shader=palette, x=x, y=y)
 
@@ -41,16 +54,19 @@ class SimpleRoundRect(displayio.TileGrid):
         self._shape = shape
 
         # clip a too large radius to the max allowed
-        radius = min(radius, width // 2, height // 2)
+        radius = min(radius, round(width / 2), round(height / 2))
 
         # calculate and apply the radius row by row
         rsqrd = radius ** 2
         for row_offset in range(0, radius):
-            left_indent = radius - round(math.sqrt(rsqrd - (row_offset - radius) ** 2))
+            left_indent = radius - int(math.sqrt(rsqrd - (row_offset - radius) ** 2))
             right_indent = width - left_indent - 1
 
-            shape.set_boundary(row_offset, left_indent, right_indent)
-            shape.set_boundary(height - row_offset - 1, left_indent, right_indent)
+            shape.set_boundary(
+                row_offset,
+                left_indent,
+                right_indent,
+            )
 
         # store for read only access later
         self._radius = radius

--- a/adafruit_display_shapes/simpleroundrect.py
+++ b/adafruit_display_shapes/simpleroundrect.py
@@ -20,8 +20,8 @@ __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_Display_Shapes.gi
 
 class SimpleRoundRect(displayio.TileGrid):
     # pylint: disable=too-many-arguments
-    """A round-corner rectangle with a smaller memory foorprint. All the corners
-        have the same same radius.
+    """A round-corner rectangle with lower memory usage than RoundRect. All the corners
+        have the same radius and no outline.
 
     :param x: The x-position of the top left corner.
     :param y: The y-position of the top left corner.
@@ -80,9 +80,9 @@ class SimpleRoundRect(displayio.TileGrid):
     @fill.setter
     def fill(self, value):
         if value is None:
-            self._palette.make_transparent(0)
+            self._palette.make_transparent(1)
         else:
-            self._palette.make_opaque(0)
+            self._palette.make_opaque(1)
             self._palette[1] = value
 
     @property

--- a/adafruit_display_shapes/simpleroundrect.py
+++ b/adafruit_display_shapes/simpleroundrect.py
@@ -20,8 +20,8 @@ __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_Display_Shapes.gi
 
 class SimpleRoundRect(displayio.TileGrid):
     # pylint: disable=too-many-arguments
-    """A round-corner rectangle with lower memory usage than RoundRect. All the corners
-        have the same radius and no outline.
+    """A round-corner rectangle with lower memory usage than RoundRect.There is
+        no outline and all the corners have the same radius.
 
     :param x: The x-position of the top left corner.
     :param y: The y-position of the top left corner.

--- a/adafruit_display_shapes/simpleroundrect.py
+++ b/adafruit_display_shapes/simpleroundrect.py
@@ -1,0 +1,82 @@
+# SPDX-FileCopyrightText: 2019 Limor Fried for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
+"""
+`simpleroundrect`
+================================================================================
+
+A slightly modified version of Adafruit_CircuitPython_Display_Shapes that includes
+an explicit call to palette.make_opaque() in the fill color setter function.
+
+"""
+
+import math
+import displayio
+
+__version__ = "0.0.0-auto.0"
+__repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_Display_Shapes.git"
+
+
+class SimpleRoundRect(displayio.TileGrid):
+    def __init__(self, x, y, width, height, radius=0, fill=0xFF0000):
+
+        # the palette and shpae can only be stored after __init__
+        palette = displayio.Palette(2)
+        shape = displayio.Shape(
+            width,
+            height,
+            # mirror_x and mirror_y are False until a core displayio bug is fixed
+            mirror_x=False,
+            mirror_y=False,
+        )
+        super().__init__(shape, pixel_shader=palette, x=x, y=y)
+
+        # configure the color and palette
+        palette.make_transparent(0)
+        palette[1] = fill
+
+        # these them so fill can be adjusted later
+        self._palette = palette
+        self._shape = shape
+
+        # clip a too large radius to the max allowed
+        radius = min(radius, width // 2, height // 2)
+
+        # calculate and apply the radius row by row
+        rsqrd = radius ** 2
+        for row_offset in range(0, radius):
+            left_indent = radius - round(math.sqrt(rsqrd - (row_offset - radius) ** 2))
+            right_indent = width - left_indent - 1
+
+            shape.set_boundary(row_offset, left_indent, right_indent)
+            shape.set_boundary(height - row_offset - 1, left_indent, right_indent)
+
+        # store for read only access later
+        self._radius = radius
+        self._width = width
+        self._height = height
+
+    @property
+    def fill(self):
+        return self._palette[1]
+
+    @fill.setter
+    def fill(self, value):
+        if value is None:
+            self._palette.make_transparent(0)
+        else:
+            self._palette.make_opaque(0)
+            self._palette[1] = value
+
+    @property
+    def width(self):
+        return self._width
+
+    @property
+    def height(self):
+        return self._height
+
+    @property
+    def radius(self):
+        return self._radius

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -24,3 +24,6 @@
 
 .. automodule:: adafruit_display_shapes.sparkline
   :members:
+
+  .. automodule:: adafruit_display_shapes.simpleroundrect
+    :members:


### PR DESCRIPTION
This proposes to add a more memory conservative version of RoundRect as discussed in CircuitPython Weekly. It trades having an outline and the ability to choose which corners have radiuses for smaller ram consumption. 

I'd love to discuss enhancements and changes.

# Implementation Notes:

## Shape vs vectorio:
This implementation uses the `displayio.Shape` primatives rather than vectorio. 
From experimental testing, Shape took significantly less memory and had better visual performance using vectorio.  
For a test of several rectangle sizes it saved about 290 bytes per rectangle and about a second on the initial render time per test page.

The test code I wrote for vectorio is  [in a gist](https://gist.github.com/TG-Techie/44548a0a20c23841ca89bf19d0c4119f)

## mirror_x Not Working:
Currently the displayio.Shape layer has a small bug in it that prevents this class from using the mirror_x argument in Shape.
When a rectangle has an odd width there is no way to set the middlemost pixel to filled. To account for this, the left and right radiuses are set manually. mirror_y is turned on and works well.
I did some poking around in the CircuitPython source code but have yet to find the comparison that is causing this.

## Radius Calculation Using Floats:
Right now this module uses floating-point calculation for finding the radius values. the RoundRect file and seems to be using an integer-based algorithm. 
While this would presumably be better, I could not understand the code at all. Nor could I figure out the calculation method they were using via googling. Any help or suggestions would be appreciated.

## API:
This proposed class uses the `radius` keyword for the radius default argument as opposed to the `r` keyword in RoundRect. This was intentional as I think it is clearer. The SimpleRoundRect already breaks the RoundRect API by excluding outline, stroke, and corner_flags; I'm open to changing for compatibility.


