### PR TITLE
Update circle.py

### DIFF
--- a/adafruit_display_shapes/circle.py
+++ b/adafruit_display_shapes/circle.py
@@ -53,3 +53,5 @@ class Circle(RoundRect):
             outline=outline,
             stroke=stroke,
         )
+        self.x0 = x0 # added by empirical-dan
+        self.y0 = y0 # added by empirical-dan

--- a/adafruit_display_shapes/circle.py
+++ b/adafruit_display_shapes/circle.py
@@ -53,5 +53,14 @@ class Circle(RoundRect):
             outline=outline,
             stroke=stroke,
         )
-        self.x0 = x0 # added by empirical-dan
-        self.y0 = y0 # added by empirical-dan
+        self.r = r
+        
+        @property
+        def x0(self):
+            """The x-position of the center."""
+            return self.x + self.r
+        
+        @property
+        def y0(self):
+            """The y-position of the center."""
+            return self.y + self.r


### PR DESCRIPTION
Added attributes x0, y0 (co-ordinates of centre of circle) to Circle Class object instance. A Circle object is defined by the centre (x0, y0) in the constructor. However, there were no attributes corresponding to this only x, y which are x0-r, y0-r due to inheritance from RoundRect (most shapes are defined by the top-left corner co-ordinate x, y). The addition of the centre of Circle attributes make it easier to locate the circle on the screen using the same reference co-ordinates used to define it.