### PR TITLE
Remove usage of max_glyphs with Label

### DIFF
--- a/examples/display_shapes_sparkline_triple.py
+++ b/examples/display_shapes_sparkline_triple.py
@@ -183,18 +183,14 @@ sparkline3 = Sparkline(
 )
 
 # Initialize the y-axis labels for mySparkline3 with no text
-text_label3a = label.Label(
-    font=font, text="", color=0x11FF44, max_glyphs=20
-)  # y_top label
+text_label3a = label.Label(font=font, text="", color=0x11FF44)  # y_top label
 text_label3a.anchor_point = (0, 0.5)  # set the anchorpoint
 text_label3a.anchored_position = (
     sparkline3.width,
     120,
 )  # set the text anchored position to the upper right of the graph
 
-text_label3b = label.Label(
-    font=font, text="", color=0x11FF44, max_glyphs=20
-)  # y_bottom label
+text_label3b = label.Label(font=font, text="", color=0x11FF44)  # y_bottom label
 text_label3b.anchor_point = (0, 0.5)  # set the anchorpoint
 text_label3b.anchored_position = (
     sparkline3.width,


### PR DESCRIPTION
Remove usage of `max_glyphs` now that it has been removed from `Adafruit_CircuitPython_Display_Text`
https://github.com/adafruit/Adafruit_CircuitPython_Display_Text/releases/tag/2.20.0

Tested on a PyPortal with `7.0.0-alpha-4`