### PR TITLE
Add color setter/getter to the Line class

### DIFF
--- a/adafruit_display_shapes/line.py
+++ b/adafruit_display_shapes/line.py
@@ -51,5 +51,3 @@ class Line(Polygon):
     def color(self, color):
         self.outline = color
         return
-      
-      

--- a/adafruit_display_shapes/line.py
+++ b/adafruit_display_shapes/line.py
@@ -40,3 +40,16 @@ class Line(Polygon):
 
     def __init__(self, x0, y0, x1, y1, color):
         super().__init__([(x0, y0), (x1, y1)], outline=color)
+    
+    @property
+    def color(self):
+        """The line color value. Can be a hex value for a color or
+        ``None`` for no line color."""
+        return self.outline
+
+    @color.setter
+    def color(self, color):
+        self.outline = color
+        return
+      
+      


### PR DESCRIPTION
Allows line color to be changed after instantiation using the Line `color` property rather than the hidden Polygon `outline` property.