### PR TITLE
add height and width properties for Rect and RoundRect

### DIFF
--- a/adafruit_display_shapes/rect.py
+++ b/adafruit_display_shapes/rect.py
@@ -95,3 +95,17 @@ class Rect(displayio.TileGrid):
         else:
             self._palette[1] = color
             self._palette.make_opaque(1)
+
+    @property
+    def width(self) -> int:
+        """
+        :return: the width of the rectangle in pixels
+        """
+        return self._bitmap.width
+
+    @property
+    def height(self) -> int:
+        """
+        :return: the height of the rectangle in pixels
+        """
+        return self._bitmap.height

--- a/adafruit_display_shapes/roundrect.py
+++ b/adafruit_display_shapes/roundrect.py
@@ -170,3 +170,17 @@ class RoundRect(displayio.TileGrid):
         else:
             self._palette[1] = color
             self._palette.make_opaque(2)
+
+    @property
+    def width(self) -> int:
+        """
+        :return: the width of the rounded rectangle in pixels
+        """
+        return self._bitmap.width
+
+    @property
+    def height(self) -> int:
+        """
+        :return: the height of the rounded rectangle in pixels
+        """
+        return self._bitmap.height


### PR DESCRIPTION
This adds `height` and `width` properties to Rect and RoundRect which are helpful when trying to center the shape inside of some other "box". For example with this change and a new feature I'm working on in GridLayout you'll be able to add shapes to the GridLayout and anchor them within the cells however you'd like. i.e.:

![image](https://user-images.githubusercontent.com/2406189/143713511-f265f7bb-6e3d-43e0-8766-81c40d6e0593.png)

All testing was preformed using Blinka_DisplayIO. Definitely would appreciate if someone can test on a micro-controller with display connected.