### PR TITLE
Guard against ZeroDivisionError

### DIFF
--- a/adafruit_display_shapes/sparkline.py
+++ b/adafruit_display_shapes/sparkline.py
@@ -146,6 +146,11 @@ class Sparkline(displayio.Group):
         else:
             self.y_top = self.y_max
 
+        # Guard for y_top and y_bottom being the same
+        if self.y_top == self.y_bottom:
+            self.y_bottom -= 10
+            self.y_top += 10
+
         if len(self._spark_list) > 2:
             xpitch = (self.width - 1) / (
                 len(self._spark_list) - 1


### PR DESCRIPTION
Resolves #46 by forcing an arbitrarily different `y_top` and `y_bottom` for sparklines if autorange is set.  This will guard against `ZeroDivisionError` until a value that will otherwise set the autorange is added.