### PR TITLE
implement parameter update for add_values()

### DIFF
--- a/adafruit_display_shapes/sparkline.py
+++ b/adafruit_display_shapes/sparkline.py
@@ -99,7 +99,7 @@ class Sparkline(displayio.Group):
             self.pop()
         self._spark_list = []  # empty the list
 
-    def add_value(self, value: float, update: boolean = True) -> None:
+    def add_value(self, value: float, update: bool = True) -> None:
         """Add a value to the sparkline.
         :param value: The value to be added to the sparkline
         :param update: trigger recreation of primitives

--- a/adafruit_display_shapes/sparkline.py
+++ b/adafruit_display_shapes/sparkline.py
@@ -99,9 +99,14 @@ class Sparkline(displayio.Group):
             self.pop()
         self._spark_list = []  # empty the list
 
-    def add_value(self, value: float) -> None:
+    def add_value(self, value: float, update: boolean = True) -> None:
         """Add a value to the sparkline.
         :param value: The value to be added to the sparkline
+        :param update: trigger recreation of primitives
+
+        Note: when adding multiple values it is more efficient to call
+        this method with parameter 'update=False' and then to manually
+        call the update()-method
         """
 
         if value is not None:
@@ -110,7 +115,8 @@ class Sparkline(displayio.Group):
             ):  # if list is full, remove the first item
                 self._spark_list.pop(0)
             self._spark_list.append(value)
-            self.update()
+            if update:
+                self.update()
 
     # pylint: disable=no-else-return
     @staticmethod


### PR DESCRIPTION
This commits adds an optional parameter `update=True` to `add_values()`. The default keeps the current behavior. Setting `update=False` results in primitives not being updated, this has to be done manually after adding a number of values.

Timing tests with a slightly modified version of `examples/display_shapes_sparkline_simpletest.py`:

    s = time.monotonic()
    for _ in range(10):
        sparkline1.add_value(random.uniform(0, 10))
    print("%f" % (time.monotonic()-s))

vs:

    s = time.monotonic()
    for _ in range(10):
        sparkline1.add_value(random.uniform(0, 10),update=False)
    sparkline1.update()
    print("%f" % (time.monotonic()-s))

The first version maxes out at about 2 seconds after the limit of 40 values is reached, the second version maxes out at 0.2 seconds. Figures measured with a PyPortal.