### PR TITLE
Docs: formatting issue for Sparkline.add_value

### DIFF
--- a/adafruit_display_shapes/sparkline.py
+++ b/adafruit_display_shapes/sparkline.py
@@ -101,6 +101,7 @@ class Sparkline(displayio.Group):
 
     def add_value(self, value: float, update: bool = True) -> None:
         """Add a value to the sparkline.
+
         :param value: The value to be added to the sparkline
         :param update: trigger recreation of primitives
 


### PR DESCRIPTION
Hello,

The documentation for the `add_value` method of the `Sparkline` class has some rendering issues, with the parameters not being listed correctly. The text `:param value:` and `:param update:` is visible on the page, instead of having the effect of listing each parameter individually.

Here's how it gets rendered ([from this page](https://docs.circuitpython.org/projects/display-shapes/en/latest/api.html#adafruit_display_shapes.sparkline.Sparkline.add_value)):

<img width="673" alt="image" src="https://user-images.githubusercontent.com/7276/178534994-268cf2db-2e05-4a83-8e09-a75af4565374.png">

I believe this is due to the lack of a new line between the description for the method and the list of parameters. This commits adds the missing line.

See for comparison how this looks for the constructor, there's a gap before `:param width`: https://github.com/adafruit/Adafruit_CircuitPython_Display_Shapes/blob/cdef09114d2b43d2e461d066a5b56697ab567abc/adafruit_display_shapes/sparkline.py#L50-L55