### PR TITLE
Added value checks for "rect" and "roundrect"

### DIFF
--- a/adafruit_display_shapes/rect.py
+++ b/adafruit_display_shapes/rect.py
@@ -59,11 +59,11 @@ class Rect(displayio.TileGrid):
         outline: Optional[int] = None,
         stroke: int = 1,
     ) -> None:
-        self._bitmap = displayio.Bitmap(width, height, 2)
-        self._palette = displayio.Palette(2)
-
         if width <= 0 or height <= 0:
             raise ValueError("Width and height must be greater than 0")
+
+        self._bitmap = displayio.Bitmap(width, height, 2)
+        self._palette = displayio.Palette(2)
 
         if outline is not None:
             self._palette[1] = outline

--- a/adafruit_display_shapes/rect.py
+++ b/adafruit_display_shapes/rect.py
@@ -60,7 +60,7 @@ class Rect(displayio.TileGrid):
         stroke: int = 1,
     ) -> None:
         if width <= 0 or height <= 0:
-            raise ValueError("Width and height must be greater than 0")
+            raise ValueError("Rectangle dimensions must be larger than 0.")
 
         self._bitmap = displayio.Bitmap(width, height, 2)
         self._palette = displayio.Palette(2)

--- a/adafruit_display_shapes/rect.py
+++ b/adafruit_display_shapes/rect.py
@@ -62,6 +62,9 @@ class Rect(displayio.TileGrid):
         self._bitmap = displayio.Bitmap(width, height, 2)
         self._palette = displayio.Palette(2)
 
+        if width <= 0 or height <= 0:
+            raise ValueError("Width and height must be greater than 0")
+
         if outline is not None:
             self._palette[1] = outline
             for w in range(width):

--- a/adafruit_display_shapes/roundrect.py
+++ b/adafruit_display_shapes/roundrect.py
@@ -68,6 +68,9 @@ class RoundRect(displayio.TileGrid):
             y_offset=height - 2 * r - 1,
         )
 
+        if width <= 0 or height <= 0:
+            raise ValueError("Width and height must be greater than 0")
+
         if fill is not None:
             self._palette[2] = fill
             self._palette.make_opaque(2)

--- a/adafruit_display_shapes/roundrect.py
+++ b/adafruit_display_shapes/roundrect.py
@@ -52,10 +52,10 @@ class RoundRect(displayio.TileGrid):
         outline: Optional[int] = None,
         stroke: int = 1,
     ) -> None:
-        if r > width / 2 or r > height / 2:
-            raise ValueError("Radius too large for given dimensions")
         if width <= 0 or height <= 0:
-            raise ValueError("Width and height must be greater than 0")
+            raise ValueError("Rectangle dimensions must be larger than 0.")
+        if r > width / 2 or r > height / 2:
+            raise ValueError("Radius cannot exceed half of the smaller side (width or height).")
 
         self._palette = displayio.Palette(3)
         self._palette.make_transparent(0)

--- a/adafruit_display_shapes/roundrect.py
+++ b/adafruit_display_shapes/roundrect.py
@@ -52,6 +52,11 @@ class RoundRect(displayio.TileGrid):
         outline: Optional[int] = None,
         stroke: int = 1,
     ) -> None:
+        if r > width / 2 or r > height / 2:
+            raise ValueError("Radius too large for given dimensions")
+        if width <= 0 or height <= 0:
+            raise ValueError("Width and height must be greater than 0")
+
         self._palette = displayio.Palette(3)
         self._palette.make_transparent(0)
         self._bitmap = displayio.Bitmap(width, height, 3)
@@ -67,9 +72,6 @@ class RoundRect(displayio.TileGrid):
             x_offset=width - 2 * r - 1,
             y_offset=height - 2 * r - 1,
         )
-
-        if width <= 0 or height <= 0:
-            raise ValueError("Width and height must be greater than 0")
 
         if fill is not None:
             self._palette[2] = fill

--- a/adafruit_display_shapes/roundrect.py
+++ b/adafruit_display_shapes/roundrect.py
@@ -55,7 +55,9 @@ class RoundRect(displayio.TileGrid):
         if width <= 0 or height <= 0:
             raise ValueError("Rectangle dimensions must be larger than 0.")
         if r > width / 2 or r > height / 2:
-            raise ValueError("Radius cannot exceed half of the smaller side (width or height).")
+            raise ValueError(
+                "Radius cannot exceed half of the smaller side (width or height)."
+            )
 
         self._palette = displayio.Palette(3)
         self._palette.make_transparent(0)


### PR DESCRIPTION
## Issue description
I encountered some bugs that were caused by user input errors (e.g. automatically assigning widths and heights => 0), leading to issues that were challenging to diagnose due to the lack of clear error messages. To address this, I have added checks for the "rect" and "roundrect" functions.

## Added checks
 These checks aim to ensure the correctness of incoming values and provide error messages if they are out-of-spec.
- Height and width validation for "rect" and "roundrect"
- Radius validation for "roundrect"