### PR TITLE
reduce unnecessary redrawing of lines in `MultiSparkLine.add_values()`

### DIFF
--- a/adafruit_display_shapes/multisparkline.py
+++ b/adafruit_display_shapes/multisparkline.py
@@ -172,8 +172,10 @@ class MultiSparkline(displayio.TileGrid):
         call the update()-method
         """
 
+        lines_to_update = []
         for i, value in enumerate(values):
             if value is not None:
+                lines_to_update.append(i)
                 top = self.y_tops[i]
                 bottom = self.y_bottoms[i]
                 if (
@@ -195,8 +197,8 @@ class MultiSparkline(displayio.TileGrid):
                 self.y_tops[i] = top
                 self.y_bottoms[i] = bottom
 
-                if update:
-                    self.update_line(i)
+        if update and lines_to_update:
+            self.update_line(lines_to_update)
 
     def _add_point(
         self,


### PR DESCRIPTION
`add_values` would repeatedly call `update` for each line where a value was added, and `update` calls `_draw` which re-draws _all_ lines each time it is called.

By keeping track of lines that need to be updated and only calling `update` once at the end of `add_values`, we avoid (by my best attempt at basic math)  $(n-1)*n$ spurious line re-draws.

Note that tracking actually changed lines is a fairly trivial saving, the main problem was in calling `update` for each value, as opposed to once at the end of the loop (for >2 values or so). 