### PR TITLE
workaround for vertical stacking issue with docs theme

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -1,0 +1,13 @@
+/*
+SPDX-FileCopyrightText: 2024 Tim Cocks for Adafruit Industries
+
+SPDX-License-Identifier: MIT
+ */
+
+/*
+Fix for horizontal stacking weirdness in the RTD theme with Python properties:
+https://github.com/readthedocs/sphinx_rtd_theme/issues/1301
+*/
+.py.property {
+  display: block !important;
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -116,6 +116,8 @@ html_static_path = ["_static"]
 #
 html_favicon = "_static/favicon.ico"
 
+html_css_files = ["custom.css"]
+
 # Output file base name for HTML help builder.
 htmlhelp_basename = "AdafruitDisplay_shapesLibrarydoc"
 


### PR DESCRIPTION
@ladyada 

Resolves: #60 

It doesn't seem like this is going to get fixed upstream any time soon. I've seen this stacking weirdness in other library docs too, might be worth adding this to cookiecutter and eventually patching to other libraries.

Screenshot of this version:
![image](https://github.com/user-attachments/assets/eef5637d-768c-4954-be90-d47b22dc7d44)
