### PR TITLE
adding filled polygon. Add support for stroke on Polygon

### DIFF
--- a/adafruit_display_shapes/filled_polygon.py
+++ b/adafruit_display_shapes/filled_polygon.py
@@ -43,7 +43,7 @@ __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_Display_Shapes.gi
 
 class FilledPolygon(displayio.Group):
     # pylint: disable=too-few-public-methods, invalid-name
-    """A filled polygon. Technically, an arc is a Group with one or two polygons.
+    """A filled polygon. Technically, an FilledPolygon is a Group with one or two polygons.
 
     :param list points: A list of (x, y) tuples of the points
     :param int|None outline: The outline of the arc. Can be a hex value for a color or

--- a/adafruit_display_shapes/filled_polygon.py
+++ b/adafruit_display_shapes/filled_polygon.py
@@ -1,0 +1,142 @@
+# SPDX-FileCopyrightText: 2024 Tim Cocks for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
+"""
+`filled_polygon`
+================================================================================
+
+Various common shapes for use with displayio - Polygon that supports
+both fill and outline
+
+
+* Author(s): Bernhard Bablok, Tim Cocks
+
+Implementation Notes
+--------------------
+
+**Software and Dependencies:**
+
+* Adafruit CircuitPython firmware for the supported boards:
+  https://github.com/adafruit/circuitpython/releases
+
+"""
+
+try:
+    from typing import Optional, List, Tuple
+except ImportError:
+    pass
+
+import displayio
+from adafruit_display_shapes.polygon import Polygon
+
+try:
+    import vectorio
+
+    HAVE_VECTORIO = True
+except ImportError:
+    HAVE_VECTORIO = False
+
+__version__ = "0.0.0+auto.0"
+__repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_Display_Shapes.git"
+
+
+class FilledPolygon(displayio.Group):
+    # pylint: disable=too-few-public-methods, invalid-name
+    """A filled polygon. Technically, an arc is a Group with one or two polygons.
+
+    :param list points: A list of (x, y) tuples of the points
+    :param int|None outline: The outline of the arc. Can be a hex value for a color or
+                    ``None`` for no outline.
+    :param int|None fill: The fill-color of the arc. Can be a hex value for a color or
+                    ``None`` for no filling. Ignored if port does not support vectorio.
+    :param bool close: (Optional) Wether to connect first and last point. (True)
+    :param int stroke: Thickness of the outline.
+
+    """
+
+    def __init__(
+        self,
+        points: List[Tuple[int, int]],
+        *,
+        outline: Optional[int] = None,
+        fill: Optional[int] = None,
+        close: Optional[bool] = True,
+        stroke: int = 1,
+    ) -> None:
+        super().__init__()
+        self._points = points
+        self._outline = outline
+        self._fill = fill
+        self.close = close
+        self.stroke = stroke
+
+        self.palette = None
+        self.vector_polygon = None
+        self.outline_polygon = None
+
+        self._init_polygon()
+
+    def _init_polygon(self):
+        # create polygon(s) and add to ourselves
+        if HAVE_VECTORIO and self._fill is not None:
+            if self.palette is None:
+                self.palette = displayio.Palette(1)
+            self.palette[0] = self._fill
+            if self.vector_polygon is None:
+                self.vector_polygon = vectorio.Polygon(
+                    pixel_shader=self.palette, points=self.points, x=0, y=0
+                )
+                self.append(self.vector_polygon)
+            else:
+                self.vector_polygon.points = self.points
+
+        if self._outline is not None:
+            if self.outline_polygon is None:
+                self.outline_polygon = Polygon(
+                    self.points,
+                    outline=self._outline,
+                    colors=1,
+                    close=self.close,
+                    stroke=self.stroke,
+                )
+            else:
+                self.remove(self.outline_polygon)
+                self.outline_polygon = Polygon(
+                    self.points,
+                    outline=self._outline,
+                    colors=1,
+                    close=self.close,
+                    stroke=self.stroke,
+                )
+            self.append(self.outline_polygon)
+
+    @property
+    def points(self):
+        """The points that make up the polygon"""
+        return self._points
+
+    @points.setter
+    def points(self, points):
+        self._points = points
+        self._init_polygon()
+
+    @property
+    def outline(self):
+        """The outline color. None for no outline"""
+        return self._outline
+
+    @outline.setter
+    def outline(self, value):
+        self._outline = value
+        self._init_polygon()
+
+    @property
+    def fill(self):
+        """The fill color. None for no fill"""
+        return self._fill
+
+    @fill.setter
+    def fill(self, value):
+        self._fill = value
+        self._init_polygon()

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -22,6 +22,9 @@
 .. automodule:: adafruit_display_shapes.polygon
   :members:
 
+.. automodule:: adafruit_display_shapes.filled_polygon
+  :members:
+
 .. automodule:: adafruit_display_shapes.sparkline
   :members:
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,7 +27,7 @@ extensions = [
 # Uncomment the below if you use native CircuitPython modules such as
 # digitalio, micropython and busio. List the modules you use. Without it, the
 # autodoc module docs will fail to generate with a warning.
-autodoc_mock_imports = ["displayio"]
+autodoc_mock_imports = ["displayio", "bitmaptools"]
 
 
 intersphinx_mapping = {

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -60,3 +60,12 @@ Example demonstrating various arcs.
 .. literalinclude:: ../examples/display_shapes_arc.py
     :caption: examples/display_shapes_arc.py
     :linenos:
+
+Filled Polygon Simple Test
+--------------------------
+
+Example demonstrating a filled polygon
+
+.. literalinclude:: ../examples/display_shapes_filled_polygon_simpletest.py
+    :caption: examples/display_shapes_filled_polygon_simpletest.py
+    :linenos:

--- a/examples/display_shapes_filled_polygon_simpletest.py
+++ b/examples/display_shapes_filled_polygon_simpletest.py
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: 2024 Tim Cocks for Adafruit Industries
+# SPDX-License-Identifier: MIT
+
+import board
+import displayio
+from adafruit_display_shapes.filled_polygon import FilledPolygon
+
+# Make the display context
+splash = displayio.Group()
+board.DISPLAY.root_group = splash
+
+# Make a background color fill
+color_bitmap = displayio.Bitmap(320, 240, 1)
+color_palette = displayio.Palette(1)
+color_palette[0] = 0xFFFFFF
+bg_sprite = displayio.TileGrid(color_bitmap, x=0, y=0, pixel_shader=color_palette)
+splash.append(bg_sprite)
+##########################################################################
+
+# Draw a star with blue outline and pink fill
+polygon = FilledPolygon(
+    [
+        (55, 40),
+        (62, 62),
+        (85, 62),
+        (65, 76),
+        (75, 100),
+        (55, 84),
+        (35, 100),
+        (45, 76),
+        (25, 62),
+        (48, 62),
+    ],
+    outline=0x0000FF,
+    stroke=4,
+    fill=0xFF00FF,
+)
+splash.append(polygon)
+
+while True:
+    pass


### PR DESCRIPTION
@ladyada 

Resolves: #63 

I opted to make a new FilledPolygon class instead of adding support to existing Polygon directly so that anyone who wants to use the traditional one doesn't have to gain the overhead of an extra Group, or have their code broken if it used some of the superclass TileGrid's attributes.  

Not strictly related to the fill support, but I also added the ability to set a `stroke` on the existing Polygon (and the new FilledPolygon). All of the other shapes support a stroke value for the thickness of their outline, but Polygon didn't before.